### PR TITLE
Fixed script to accommodate missing key in l10n files

### DIFF
--- a/Scribe-i18n/Scripts/convert_to_xcstrings.py
+++ b/Scribe-i18n/Scripts/convert_to_xcstrings.py
@@ -24,7 +24,10 @@ for pos, key in enumerate(file, start=1):
             lang_json = json.loads(
                 open(os.path.join(directory, f"{lang}.json"), "r").read()
             )
-            translation = lang_json[key].replace('"', '\\"').replace("\n", "\\n")
+            if key in lang_json:
+                translation = lang_json[key].replace('"', '\\"').replace("\n", "\\n")
+            else:
+                translation = ""
             if translation != "":
                 data += (
                     f'        "{lang}" : {{\n'


### PR DESCRIPTION
The current script breaks because Weblate only adds a key to a language file when there's a translation for it. This caused the conversion to xcstrings to stop working and stopped updating the Xcode file.