### PR TITLE
Removed conditional from xcstrings conversion action

### DIFF
--- a/.github/workflows/xcstrings_conversion.yml
+++ b/.github/workflows/xcstrings_conversion.yml
@@ -6,32 +6,10 @@ on:
       - main
 
 jobs:
-  # Check to make sure the localization files have actually changed.
-  conditional_job_check_files:
+  # Run xcstrings conversion script.
+  run_conversion:
     runs-on: ubuntu-latest
-    outputs:
-      json_changed: ${{ steps.check_file_changed.outputs.json_changed }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - shell: pwsh
-        id: check_file_changed
-        run: |
-          $diff = git diff --name-only HEAD^ HEAD
-
-          $SourceDiff = $diff | Where-Object { $_ -match '^Scribe-i18n/' -and $_ -match '.json$' }
-          $HasDiff = $SourceDiff.Length -gt 0
-
-          Write-Host "json_changed=$HasDiff" >> "$GITHUB_OUTPUT"
-
-  # Run xcstrings conversion script if needed.
-  conditional_job:
-    runs-on: ubuntu-latest
-    needs:
-      - conditional_job_check_files
-    if: needs.conditional_job_check_files.outputs.json_changed == True
+    name: Run xcstrings conversion script
     steps:
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Removed the conditional from the xcstrings_conversion.yml action, because it caused issues with the execution. Executing the action on every push to main should be fine, since we don't plan on making many changes to this repo apart from localization updates.